### PR TITLE
Add missing argument to `open` call

### DIFF
--- a/src/nsca.c
+++ b/src/nsca.c
@@ -477,7 +477,7 @@ static int read_config_file(char *filename){
                             int checkresult_test_fd=-1;
                             char *checkresult_test=NULL;
                             asprintf(&checkresult_test,"%s/nsca.test.%i",check_result_path,getpid());
-                            checkresult_test_fd=open(checkresult_test,O_WRONLY|O_CREAT);
+                            checkresult_test_fd=open(checkresult_test,O_WRONLY|O_CREAT, S_IRUSR|S_IWUSR);
                             if (checkresult_test_fd>0){
                                     unlink(checkresult_test);
                                     }


### PR DESCRIPTION
_TL;DR;_ When using the O_CREAT flag in the 'open' function call, you'd better to provide the mode explicitly, or the Ubuntu user cries.

When trying to compile nsca on my Ubuntu 14.04, I got the following:

```
/usr/include/x86_64-linux-gnu/bits/fcntl2.h:50:24: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT in second argument needs 3 arguments
    __open_missing_mode ();
                        ^
make[1]: *** [nsca] Error 1
```

Starting from Ubuntu 8.10, the compiler flag -D_FORTIFY_SOURCE=2 is used by default. This causes the compiler to check for compile-time best-practices errors when calling certain libc functions.
This is the case for `open`, where the mode should be explicitly set rather than inferred from the process umask.

References:

http://linux.die.net/man/2/open
https://wiki.ubuntu.com/ToolChain/CompilerFlags?action=show&redirect=CompilerFlags#A-D_FORTIFY_SOURCE.3D2
