### PR TITLE
send_nsca: support server version <2.9

### DIFF
--- a/sample-config/send_nsca.cfg.in
+++ b/sample-config/send_nsca.cfg.in
@@ -61,3 +61,6 @@
 
 encryption_method=1
 
+# Run in version 2.7  backward compatibility mode
+# Sent packages are limited to 512 bytes
+# legacy_2_7_mode=true

--- a/src/send_nsca.c
+++ b/src/send_nsca.c
@@ -261,15 +261,15 @@ int main(int argc, char **argv){
 		if(ptr4==NULL){
 			strcpy(svc_description,"");
 			return_code=atoi(ptr2);
-      ptr3=escape_newlines(ptr3);
+			ptr3=escape_newlines(ptr3);
 			strncpy(plugin_output,ptr3,plugin_output_length-1);
-    }
+		}
 		else{
 			strncpy(svc_description,ptr2,sizeof(svc_description)-1);
 			return_code=atoi(ptr3);
-      ptr4=escape_newlines(ptr4);
+			ptr4=escape_newlines(ptr4);
 			strncpy(plugin_output,ptr4,plugin_output_length-1);
-    }
+		}
 
 		svc_description[sizeof(svc_description)-1]='\x0';
 		plugin_output[plugin_output_length-1]='\x0';


### PR DESCRIPTION
Commit 7256213ef1b3b937e991a8ff5d8782de98d5a11b leads to
incompatibility between different server and client versions.
This commit adds an option to the send_nsca utility to work in
legacy 2.7 mode. If "legacy_2_7_mode=true" is added to
send_nsca.cfg a 2.7 nsca server does not longer drop received
packages.