### PR TITLE
nsca ipv6 server support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,10 @@ AC_CHECK_LIB(wrap,main,[
 AC_SUBST(LIBWRAPLIBS)
 AC_CHECK_FUNCS(strdup strstr strtoul sigaction)
 
+dnl we require modern address resolution functions.
+AC_CHECK_FUNCS([getnameinfo getaddrinfo], ,
+	[AC_MSG_ERROR([Missing address resolution functions])])
+
 dnl Define sig_atomic_t to int if it's not available.
 AC_CHECK_TYPE([sig_atomic_t],[],[
 	AC_DEFINE([sig_atomic_t],[int],

--- a/src/nsca.c
+++ b/src/nsca.c
@@ -24,7 +24,7 @@
 
 
 static int server_port=DEFAULT_SERVER_PORT;
-static char server_address[16]="0.0.0.0";
+static char server_address[64]="";
 static int socket_timeout=DEFAULT_SOCKET_TIMEOUT;
 static int log_facility=LOG_DAEMON;
 
@@ -805,18 +805,63 @@ static void handle_events(void){
 
 /* wait for incoming connection requests */
 static void wait_for_connections(void) {
-        struct sockaddr_in myname;
+        struct addrinfo hints, *ai;
+        char portbuf[16];
+        char *sa;
+        int r;
         int sock=0;
+        int v6ok=0;
         int flag=1;
 
+        /* check to see if we have ipv6 support */
+        if ((sock = socket(AF_INET6, SOCK_STREAM, 0)) >= 0) {
+                close(sock);
+                v6ok=1;
+        }
+
+        sa = server_address[0] ? server_address : NULL;
+#ifndef IPV6_V6ONLY
+        if (sa == NULL)
+                sa = "0.0.0.0";
+#endif
+
+        /* what address should we bind to? */
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_flags = AI_ADDRCONFIG | AI_PASSIVE;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_protocol = IPPROTO_TCP;
+        if (v6ok && sa == NULL) {
+                hints.ai_family = AF_INET6;
+                hints.ai_flags |= AI_V4MAPPED;
+        }
+        snprintf(portbuf, sizeof(portbuf), "%d", server_port);
+        r = getaddrinfo(sa, portbuf, &hints, &ai);
+        if (r != 0) {
+                syslog(LOG_ERR,"Server address %s port %s: %s",
+                                sa ? sa : "<any>", portbuf, gai_strerror(r));
+                do_exit(STATE_CRITICAL);
+        }
+
         /* create a socket for listening */
-        sock=socket(AF_INET,SOCK_STREAM,0);
+        sock=socket(ai->ai_family,ai->ai_socktype,0);
 
         /* exit if we couldn't create the socket */
         if(sock<0){
                 syslog(LOG_ERR,"Network server socket failure (%d: %s)",errno,strerror(errno));
                 do_exit(STATE_CRITICAL);
                 }
+
+#ifdef IPV6_V6ONLY
+        /* serve both v4 and v6 on a single socket ? */
+        if (sa == NULL && ai->ai_family == AF_INET6) {
+                r = 0;
+                if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &r, sizeof(r)) < 0) {
+                        syslog(LOG_ERR,"Could not set IPV6_V6ONLY=0 option on socket!\n");
+                        do_exit(STATE_CRITICAL);
+                }
+        }
+#endif
 
         /* set the reuse address flag so we don't get errors when restarting */
         flag=1;
@@ -825,24 +870,13 @@ static void wait_for_connections(void) {
                 do_exit(STATE_CRITICAL);
                 }
 
-        myname.sin_family=AF_INET;
-        myname.sin_port=htons(server_port);
-        bzero(&myname.sin_zero,8);
-
-        /* what address should we bind to? */
-        if(!strlen(server_address))
-                myname.sin_addr.s_addr=INADDR_ANY;
-        else if(!my_inet_aton(server_address,&myname.sin_addr)){
-                syslog(LOG_ERR,"Server address is not a valid IP address\n");
-                do_exit(STATE_CRITICAL);
-                }
-
 
         /* bind the address to the Internet socket */
-        if(bind(sock,(struct sockaddr *)&myname,sizeof(myname))<0){
+        if(bind(sock,ai->ai_addr,ai->ai_addrlen)<0){
                 syslog(LOG_ERR,"Network server bind failure (%d: %s)\n",errno,strerror(errno));
                 do_exit(STATE_CRITICAL);
                 }
+        freeaddrinfo(ai);
 
         /* open the socket for listening */
         if(listen(sock,SOMAXCONN)<0){
@@ -854,7 +888,7 @@ static void wait_for_connections(void) {
         syslog(LOG_NOTICE,"Starting up daemon");
 
         if(debug==TRUE){
-                syslog(LOG_DEBUG,"Listening for connections on port %d\n",htons(myname.sin_port));
+                syslog(LOG_DEBUG,"Listening for connections on port %d\n",server_port);
                 }
 
 	/* socket should be non-blocking for mult-process daemon */
@@ -890,9 +924,10 @@ static void wait_for_connections(void) {
 static void accept_connection(int sock, void *unused){
         int new_sd;
         pid_t pid;
-        struct sockaddr addr;
-        struct sockaddr_in *nptr;
+        struct sockaddr_storage addr;
         socklen_t addrlen;
+        char hostbuf[64], portbuf[16];
+        char *h;
         int rc;
 #ifdef HAVE_LIBWRAP
 	struct request_info req;
@@ -973,7 +1008,7 @@ static void accept_connection(int sock, void *unused){
 
         /* find out who just connected... */
         addrlen=sizeof(addr);
-        rc=getpeername(new_sd,&addr,&addrlen);
+        rc=getpeername(new_sd,(struct sockaddr *)&addr,&addrlen);
 
         if(rc<0){
                 /* log error to syslog facility */
@@ -986,11 +1021,15 @@ static void accept_connection(int sock, void *unused){
 		return;
                 }
 
-        nptr=(struct sockaddr_in *)&addr;
-
         /* log info to syslog facility */
-        if(debug==TRUE)
-                syslog(LOG_DEBUG,"Connection from %s port %d",inet_ntoa(nptr->sin_addr),nptr->sin_port);
+        if(debug==TRUE) {
+                getnameinfo((struct sockaddr *)&addr, addrlen,
+                        hostbuf, sizeof(hostbuf),
+                        portbuf, sizeof(portbuf),
+                        NI_NUMERICHOST|NI_NUMERICSERV);
+		h = strncmp(hostbuf, "::ffff:", 7) == 0 ? hostbuf + 7 : hostbuf;
+                syslog(LOG_DEBUG,"Connection from %s port %s",h,portbuf);
+                }
 
 	/* handle the connection */
 	if(mode==SINGLE_PROCESS_DAEMON)


### PR DESCRIPTION
There is already a [PR for IPv6 support for the nsca client](https://github.com/NagiosEnterprises/nsca/pull/6). This patch adds IPv6 support to the server side of nsca.

We have the client running on a few hundred mixed IPv4 only / IPv4 + IPv6 / IPv6 only servers, talking to a dualstack IPv4 + IPv6 server running this code.

Note that I have added a check for getaddrinfo / getnameinfo to configure.ac, since those are now mandatory. That was already true for the [IPv6 support for the nsca client](https://github.com/NagiosEnterprises/nsca/pull/6) patch, by the way.