### PR TITLE
Compile warning fixes

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -53,7 +53,7 @@ unsigned long calculate_crc32(char *, int);
 int encrypt_init(char *,int,char *,struct crypt_instance **);
 void encrypt_cleanup(int,struct crypt_instance *);
 
-static void generate_transmitted_iv(char *transmitted_iv);
+void generate_transmitted_iv(char *transmitted_iv);
 
 void encrypt_buffer(char *,int,char *,int,struct crypt_instance *);
 void decrypt_buffer(char *,int,char *,int,struct crypt_instance *);

--- a/src/send_nsca.c
+++ b/src/send_nsca.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv){
 #endif
 		printf("\n");
 		if(legacy_2_7_mode){
-			printf("Running in compatibility mode (server < V2.9, legacy plugin output length is %d bytes)\n", plugin_output_length);
+			printf("Running in compatibility mode (server < V2.9, legacy plugin output length is %ld bytes)\n", plugin_output_length);
 		}
 		printf("\n");
 	}

--- a/src/utils.c
+++ b/src/utils.c
@@ -270,7 +270,7 @@ void encrypt_cleanup(int encryption_method, struct crypt_instance *CI){
 
 
 /* generates IV to use for encrypted communications (function is called by server only, client uses IV it receives from server) */
-static void generate_transmitted_iv(char *transmitted_iv){
+void generate_transmitted_iv(char *transmitted_iv){
         FILE *fp;
         int x;
         int seed=0;


### PR DESCRIPTION
Here are 2 commits fixing a format warning  and 2 unused function warnings.