### PR TITLE
Add --quiet option to send_nsca

### DIFF
--- a/src/send_nsca.c
+++ b/src/send_nsca.c
@@ -120,9 +120,10 @@ int main(int argc, char **argv){
 	}
 
 	if(result!=OK || show_help==TRUE){
-		printf("Usage: %s -H <host_address> [-p port] [-to to_sec] [-d delim] [-ds set_delim] [-c config_file]\n",argv[0]);
+		printf("Usage: %s [--quiet] -H <host_address> [-p port] [-to to_sec] [-d delim] [-ds set_delim] [-c config_file]\n",argv[0]);
 		printf("\n");
 		printf("Options:\n");
+		printf(" --quiet        : Be quiet unless there are errors\n");
 		printf(" <host_address> = The IP address of the host running the NSCA daemon\n");
 		printf(" [port]         = The port on which the daemon is running - default is %d\n",DEFAULT_SERVER_PORT);
 		printf(" [to_sec]       = Number of seconds before connection attempt times out.\n");

--- a/src/send_nsca.c
+++ b/src/send_nsca.c
@@ -45,6 +45,7 @@ struct crypt_instance *CI=NULL;
 int show_help=FALSE;
 int show_license=FALSE;
 int show_version=FALSE;
+int verbose=TRUE;
 
 
 int process_arguments(int,char **);
@@ -349,7 +350,8 @@ int main(int argc, char **argv){
 	/* close the connection */
 	close(sd);
 
-	printf("%d data packet(s) sent to host successfully.\n",total_packets);
+	if (total_packets == 0 || verbose)
+		printf("%d data packet(s) sent to host successfully.\n",total_packets);
 
 	/* exit cleanly */
 	do_exit(STATE_OK);
@@ -449,6 +451,10 @@ int process_arguments(int argc, char **argv){
 		/* show version */
 		else if(!strcmp(argv[x-1],"-V") || !strcmp(argv[x-1],"--version"))
 			show_version=TRUE;
+
+		/* be quiet unless there are errors */
+		else if(!strcmp(argv[x-1],"--quiet"))
+			verbose=FALSE;
 
 		/* server name/address */
 		else if(!strcmp(argv[x-1],"-H")){


### PR DESCRIPTION
The addition of a --quiet option was requested in #12 
It provides a patch, but no pull request was done, so here it is.
Apparently, Debian provides a man page for send_nsca, but this manpage is not in upstream code, so I left the second patch out. However, I added another commit to document --quiet in the usage message.