### PR TITLE
Add systemd unit file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -53,6 +53,7 @@ distclean: clean
 	cd package/solaris; $(MAKE) $@ ; cd ../..
 	rm -f conf.libmcrypttest config.log config.status config.cache init-script Makefile subst $(SRC_INCLUDE)config.h
 	rm -f sample-config/nsca.cfg sample-config/send_nsca.cfg sample-config/nsca.xinetd
+	rm -f nsca.service
 
 devclean: distclean
 

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AC_CONFIG_FILES([Makefile
 	src/Makefile
 	package/solaris/Makefile
 	init-script
+	nsca.service
 	sample-config/nsca.cfg
 	sample-config/send_nsca.cfg
 	sample-config/nsca.xinetd])
@@ -268,6 +269,7 @@ AC_PATH_PROG(PERL,perl)
 AC_OUTPUT()
 
 perl subst init-script
+perl subst nsca.service
 perl subst sample-config/nsca.xinetd
 perl subst sample-config/nsca.cfg
 perl subst sample-config/send_nsca.cfg

--- a/nsca.service.in
+++ b/nsca.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Nagios Service Check Acceptor
+After=syslog.target network.target local-fs.target
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/nsca
+ExecStart=@bindir@/nsca $OPTIONS -c @sysconfdir@/nsca.cfg
+ExecReload=/bin/kill -HUP $MAINPID
+Type=forking
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I've been carrying a systemd unit file in downstream rpm for Fedora/EPEL for years, it's high time to have this upstream.