### PR TITLE
Add missing stdio.h include in send_nsca.c

### DIFF
--- a/src/send_nsca.c
+++ b/src/send_nsca.c
@@ -15,10 +15,12 @@
 
 /*#define DEBUG*/
 
+#define _GNU_SOURCE
 #include "../include/common.h"
 #include "../include/config.h"
 #include "../include/netutils.h"
 #include "../include/utils.h"
+#include <stdio.h>
 
 time_t start_time,end_time;
 


### PR DESCRIPTION
Add missing stdio.h include in send_nsca.c

Fixes a build warning:
./send_nsca.c: In function 'alarm_handler':
./send_nsca.c:547:2: warning: implicit declaration of function 'asprintf'; did you mean 'vsprintf'? [-Wimplicit-function-declaration]
  547 |  asprintf(&msg, "Error: Timeout after %d seconds\n",socket_timeout);
      |  ^~~~~~~~
      |  vsprintf

This was introduced in 413b313af603a90bc71b72c0f286a01661a1b365