### PR TITLE
#48 - Improved Error Clarity When Running in Foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 NSCA Changelog
 ==============
-
+2.10.3 - 2024-XX-XX
+-------------------
+ * Improved clarity of error when running in the foreground while already running in the background
+ 
 2.10.2 - 2022-06-06
 -------------------
  * Fixed exiting with STATE_OK when no packets were successfully sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 NSCA Changelog
 ==============
-2.10.3 - 2024-XX-XX
+2.10.3 - 2024-07-30
 -------------------
  * Improved clarity of error when running in the foreground while already running in the background
  

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,3 +28,4 @@ A full list of authors, contributors, and maintainers is as follows:
  * Ralf Ertzinger
  * David Luyer
  * Jay McCarthy
+ * Griffin Westerman (Nagios)

--- a/configure
+++ b/configure
@@ -2367,9 +2367,9 @@ ac_config_files="$ac_config_files Makefile subst src/Makefile package/solaris/Ma
 
 
 PKG_NAME=nsca
-PKG_VERSION="2.10.2"
+PKG_VERSION="2.10.3"
 PKG_HOME_URL="http://www.nagios.org/"
-PKG_REL_DATE="2022-06-06"
+PKG_REL_DATE="2024-07-30"
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl Disable caching
 define([AC_CACHE_LOAD],)
 define([AC_CACHE_SAVE],)
 
-AC_INIT([nsca],[2.10.2],[nagios-users@lists.sourceforge.net],[nsca],[http://www.nagios.org])
+AC_INIT([nsca],[2.10.3],[nagios-users@lists.sourceforge.net],[nsca],[http://www.nagios.org])
 AC_CONFIG_SRCDIR([src/nsca.c])
 AC_CONFIG_HEADER(include/config.h)
 AC_CONFIG_FILES([Makefile
@@ -19,9 +19,9 @@ AC_CONFIG_FILES([Makefile
 AC_PREFIX_DEFAULT(/usr/local/nagios)
 
 PKG_NAME=nsca
-PKG_VERSION="2.10.2"
+PKG_VERSION="2.10.3"
 PKG_HOME_URL="http://www.nagios.org/"
-PKG_REL_DATE="2022-06-06"
+PKG_REL_DATE="2024-07-30"
 AC_SUBST(PKG_NAME)
 AC_SUBST(PKG_VERSION)
 AC_SUBST(PKG_HOME_URL)

--- a/include/common.h
+++ b/include/common.h
@@ -2,7 +2,7 @@
  *
  * COMMON.H - NSCA Common Include File
  * Copyright (c) 1999-2003 Ethan Galstad (nagios@nagios.org)
- * Last Modified: 2022-06-06
+ * Last Modified: 2024-07-30
  *
  * License:
  *
@@ -24,8 +24,8 @@
 #include "config.h"
 
 
-#define PROGRAM_VERSION "2.10.2"
-#define MODIFICATION_DATE "2022-06-06"
+#define PROGRAM_VERSION "2.10.3"
+#define MODIFICATION_DATE "2024-07-30"
 
 
 #define OK		0

--- a/nsca.spec
+++ b/nsca.spec
@@ -1,5 +1,5 @@
 %define name nsca
-%define version 2.10.2
+%define version 2.10.3
 %define release 1
 %define nsusr nagios
 %define nsgrp nagios

--- a/src/nsca.c
+++ b/src/nsca.c
@@ -225,15 +225,17 @@ int main(int argc, char **argv){
 			signal(SIGHUP,sighandler);
 #endif /* HAVE_SIGACTION */
 
-			/* close standard file descriptors */
-                        close(0);
-                        close(1);
-                        close(2);
+                        if (!foreground) {
+                                /* close standard file descriptors */
+                                close(0);
+                                close(1);
+                                close(2);
 
-			/* redirect standard descriptors to /dev/null */
-			open("/dev/null",O_RDONLY);
-			open("/dev/null",O_WRONLY);
-			open("/dev/null",O_WRONLY);
+                                /* redirect standard descriptors to /dev/null */
+                                open("/dev/null",O_RDONLY);
+                                open("/dev/null",O_WRONLY);
+                                open("/dev/null",O_WRONLY);
+                        }
 
 			/* get group information before chrooting */
 			get_user_info(nsca_user,&uid);
@@ -1685,6 +1687,7 @@ static int write_pid_file(uid_t usr, gid_t grp){
 
 			/* previous process is still running */
 			else{
+                                if (foreground) printf("There's already an NSCA server running (PID %lu).  Bailing out...\n",(unsigned long)pid);
 				syslog(LOG_ERR,"There's already an NSCA server running (PID %lu).  Bailing out...",(unsigned long)pid);
 				return ERROR;
 			        }

--- a/src/nsca.c
+++ b/src/nsca.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2000-2009 Ethan Galstad (egalstad@nagios.org)
  * License: GPL v2
  *
- * Last Modified: 2022-06-06
+ * Last Modified: 2024-07-30
  *
  * Command line: NSCA -c <config_file> [mode]
  *

--- a/src/send_nsca.c
+++ b/src/send_nsca.c
@@ -4,7 +4,7 @@
  * License: GPL v2
  * Copyright (c) 2000-2007 Ethan Galstad (nagios@nagios.org)
  *
- * Last Modified: 2022-06-06
+ * Last Modified: 2024-07-30
  *
  * Command line: SEND_NSCA <host_address> [-p port] [-to to_sec] [-c config_file]
  *

--- a/update-version
+++ b/update-version
@@ -10,10 +10,10 @@ else
 fi
 
 # Current version number
-CURRENTVERSION=2.10.2
+CURRENTVERSION=2.10.3
 
 # Last date
-LASTDATE=2022-06-06
+LASTDATE=2024-07-30
 
 if [ "x$1" = "x" ]
 then


### PR DESCRIPTION
### SUMMARY
- When running nsca in the foreground while nsca is already running, the process will simply exit with an exit code of 2.
- This caused some confusion as running nsca in the background while nsca is already running will complete successfully (while logging the error).
- As far as I could tell, this was the cause of the issue noted in #48. I can run nsca in the foreground fine if it is not already running.

### FIX
- I made it such that when you run nsca in the foreground, if nsca is already running, the descriptive error will be printed to stdout.

### TESTING PLAN
- Run nsca normally.
- Run nsca normally while nsca is already running.
- Run nsca in the foreground (make sure nsca is not already running, i.e. kill the process).
- Run nsca in the foreground while nsca is already running in the background. It should print a descriptive message.